### PR TITLE
feat: adiciona paginação no endpoint GET de produtos

### DIFF
--- a/StockApp.API/Controllers/ProductController.cs
+++ b/StockApp.API/Controllers/ProductController.cs
@@ -22,4 +22,15 @@ public class ProductController : ControllerBase
         var products = await _service.SearchAsync(name, minPrice, maxPrice);
         return Ok(products);
     }
+    [HttpGet]
+    public async Task<IActionResult> GetAll(
+    [FromQuery] int pageNumber = 1,
+    [FromQuery] int pageSize = 10)
+    {
+        if (pageNumber <= 0) pageNumber = 1;
+        if (pageSize <= 0) pageSize = 10;
+
+        var products = await _service.GetAllAsync(pageNumber, pageSize);
+        return Ok(products);
+    }
 }

--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -25,6 +25,9 @@ if (string.IsNullOrEmpty(connectionString))
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 
+builder.Services.AddScoped<IProductRepository, ProductRepository>();
+
+
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/StockApp.Application/Interfaces/IProductService.cs
+++ b/StockApp.Application/Interfaces/IProductService.cs
@@ -1,9 +1,4 @@
 ﻿using StockApp.Application.DTOs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StockApp.Application.Interfaces
 {
@@ -14,7 +9,7 @@ namespace StockApp.Application.Interfaces
         Task Add(ProductDTO productDto);
         Task Update(ProductDTO productDto);
         Task Remove(int? id);
-        Task<IEnumerable<ProductDTO>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);   
-
+        Task<IEnumerable<ProductDTO>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);
+        Task<IEnumerable<ProductDTO>> GetAllAsync(int pageNumber, int pageSize);
     }
 }

--- a/StockApp.Application/Services/ProductService.cs
+++ b/StockApp.Application/Services/ProductService.cs
@@ -3,11 +3,6 @@ using StockApp.Application.DTOs;
 using StockApp.Application.Interfaces;
 using StockApp.Domain.Entities;
 using StockApp.Domain.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StockApp.Application.Services
 {
@@ -54,6 +49,11 @@ namespace StockApp.Application.Services
         public async Task<IEnumerable<ProductDTO>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice)
         {
             var products = await _productRepository.SearchAsync(name, minPrice, maxPrice);
+            return _mapper.Map<IEnumerable<ProductDTO>>(products);
+        }
+        public async Task<IEnumerable<ProductDTO>> GetAllAsync(int pageNumber, int pageSize)
+        {
+            var products = await _productRepository.GetAllAsync(pageNumber, pageSize);
             return _mapper.Map<IEnumerable<ProductDTO>>(products);
         }
 

--- a/StockApp.Domain.Test/ProductServiceTests.cs
+++ b/StockApp.Domain.Test/ProductServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using AutoMapper;
+using Moq;
+using StockApp.Application.DTOs;
+using StockApp.Application.Services;
+using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+
+public class ProductServiceTests
+{
+    private readonly Mock<IProductRepository> _mockRepo;
+    private readonly IMapper _mapper;
+    private readonly ProductService _service;
+
+    public ProductServiceTests()
+    {
+        _mockRepo = new Mock<IProductRepository>();
+
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Product, ProductDTO>();
+        });
+        _mapper = config.CreateMapper();
+
+        _service = new ProductService(_mockRepo.Object, _mapper);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsPagedProducts()
+    {
+        var products = new List<Product>
+    {
+        new Product("Produto 1", "Descrição 1", 10m, 5, "imagem1.jpg"),
+        new Product("Produto 2", "Descrição 2", 20m, 3, "imagem2.jpg"),
+        new Product("Produto 3", "Descrição 3", 30m, 2, "imagem3.jpg")
+    };
+
+        _mockRepo.Setup(r => r.GetAllAsync(1, 2))
+            .ReturnsAsync(products.Take(2));
+
+        var result = await _service.GetAllAsync(1, 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count());
+        Assert.Equal("Produto 1", result.First().Name);
+    }
+
+}

--- a/StockApp.Domain/Interfaces/IProductRepository.cs
+++ b/StockApp.Domain/Interfaces/IProductRepository.cs
@@ -1,9 +1,4 @@
 ﻿using StockApp.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StockApp.Domain.Interfaces
 {
@@ -14,7 +9,8 @@ namespace StockApp.Domain.Interfaces
         Task<Product> Create(Product product);
         Task<Product> Update(Product product);
         Task<Product> Remove(Product product);
-
-        Task<IEnumerable<Product>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);
+        Task<IEnumerable<Product>> GetAllAsync(int pageNumber, int pageSize);
+    Task<IEnumerable<Product>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);
     }
+
 }

--- a/StockApp.Infra.Data/Repositories/ProductRepository.cs
+++ b/StockApp.Infra.Data/Repositories/ProductRepository.cs
@@ -75,5 +75,12 @@ namespace StockApp.Infra.Data.Repositories
 
             return await query.ToListAsync();
         }
+        public async Task<IEnumerable<Product>> GetAllAsync(int pageNumber, int pageSize)
+        {
+            return await _productContext.Products
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
### O que foi feito

- Implementação de paginação no endpoint GET /api/product;
- Permite parâmetros query `pageNumber` e `pageSize`;
- Ajuste no repositório e serviço para suportar paginação;
- Teste unitário básico para o método GetAllAsync no ProductService.

### Por que

Essa melhoria possibilita a listagem eficiente dos produtos, evitando carregamento excessivo de dados e melhorando a performance da API.

### Issue

Closes #32 
