### PR TITLE
feat: implementar endpoint e testes para relatório de estoque baixo

### DIFF
--- a/StockApp.API/Controllers/ProductController.cs
+++ b/StockApp.API/Controllers/ProductController.cs
@@ -58,4 +58,12 @@ public class ProductController : ControllerBase
 
         return Ok(products);
     }
+
+    [HttpGet("low-stock")]
+    public async Task<ActionResult<IEnumerable<ProductDTO>>> GetLowStock([FromQuery] int threshold)
+    {
+        var products = await _service.GetLowStockAsync(threshold);
+        return Ok(products);
+    }
+
 }

--- a/StockApp.Application/Interfaces/IProductService.cs
+++ b/StockApp.Application/Interfaces/IProductService.cs
@@ -14,5 +14,7 @@ namespace StockApp.Application.Interfaces
         Task<IEnumerable<ProductDTO>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);
         Task<IEnumerable<ProductDTO>> GetAllAsync(int pageNumber, int pageSize);
         Task<IEnumerable<ProductDTO>> GetProductsByIdsAsync(List<int> productIds);
+        Task<IEnumerable<ProductDTO>> GetLowStockAsync(int threshold);
+
     }
 }

--- a/StockApp.Application/Services/ProductService.cs
+++ b/StockApp.Application/Services/ProductService.cs
@@ -69,5 +69,11 @@ namespace StockApp.Application.Services
             var products = await _productRepository.GetAllAsync(pageNumber, pageSize);
             return _mapper.Map<IEnumerable<ProductDTO>>(products);
         }
+        public async Task<IEnumerable<ProductDTO>> GetLowStockAsync(int threshold)
+        {
+            var products = await _productRepository.GetLowStockAsync(threshold);
+            return _mapper.Map<IEnumerable<ProductDTO>>(products);
+        }
+
     }
 }

--- a/StockApp.Domain/Interfaces/IProductRepository.cs
+++ b/StockApp.Domain/Interfaces/IProductRepository.cs
@@ -14,5 +14,7 @@ namespace StockApp.Domain.Interfaces
         Task<IEnumerable<Product>> GetAllAsync(int pageNumber, int pageSize);
         Task<IEnumerable<Product>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);
         Task<IEnumerable<Product>> GetByIdsAsync(List<int> productIds);
+        Task<IEnumerable<Product>> GetLowStockAsync(int threshold);
+
     }
 }

--- a/StockApp.Infra.Data/Repositories/ProductRepository.cs
+++ b/StockApp.Infra.Data/Repositories/ProductRepository.cs
@@ -90,5 +90,12 @@ namespace StockApp.Infra.Data.Repositories
         {
             return await _productContext.Products.Where(p => productIds.Contains(p.Id)).ToListAsync();
         }
+        public async Task<IEnumerable<Product>> GetLowStockAsync(int threshold)
+        {
+            return await _productContext.Products
+                .Where(p => p.Stock <= threshold)
+                .ToListAsync();
+        }
+
     }
 }


### PR DESCRIPTION
# Implementação do Relatório de Estoque Baixo

Esta PR adiciona a funcionalidade para consultar produtos com estoque abaixo de um determinado limite, facilitando o monitoramento e controle do inventário.

## Principais mudanças

- Adicionado método `GetLowStockAsync(int threshold)` no repositório e serviço.
- Criado endpoint `GET /api/Product/low-stock?threshold={valor}` que retorna produtos com estoque menor ou igual ao limite informado.
- Implementados testes unitários para validar o filtro de estoque baixo.
- Ajustes nas descrições dos produtos nos testes para atender as regras de validação do domínio.

## Benefícios

- Melhora o controle do estoque, permitindo ações preventivas para evitar falta de produtos.
- Facilita a visualização rápida dos produtos com estoque crítico.

Closes#35
