### PR TITLE
Implementação de Dashboard de estoque

### DIFF
--- a/StockApp.API/Controllers/DashboardController.cs
+++ b/StockApp.API/Controllers/DashboardController.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore; 
+using StockApp.Application.DTOs; 
+using StockApp.Infra.Data.Context;
+
+namespace StockApp.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")] 
+    public class DashboardController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context; 
+
+        public DashboardController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("dashboard-stock")]
+        public async Task<IActionResult> GetDashboardstockData()
+        {
+            var dashboardData = new DashboardstockDTO
+            {
+                TotalProducts = await _context.Products.CountAsync(),
+                TotalStockValue = await _context.Products.SumAsync(p => p.Stock * p.Price),
+                LowStockProducts = await _context.Products
+                    .Where(p => p.Stock < 10)
+                    .Select(p => new ProductstockDTO
+                    {
+                        ProductName = p.Name,
+                        Stock = p.Stock
+                    })
+                    .ToListAsync()
+            };
+
+            return Ok(dashboardData);
+        }
+    }
+}

--- a/StockApp.Application/DTOs/DashboardstockDTO.cs
+++ b/StockApp.Application/DTOs/DashboardstockDTO.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace StockApp.Application.DTOs
+{
+    public class DashboardstockDTO
+    {
+        public int TotalProducts { get; set; }
+        public decimal TotalStockValue { get; set; }
+        public List<ProductstockDTO> LowStockProducts { get; set; }
+    }
+}

--- a/StockApp.Application/DTOs/ProductstockDTO.cs
+++ b/StockApp.Application/DTOs/ProductstockDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace StockApp.Application.DTOs
+{
+    public class ProductstockDTO
+    {
+        public string ProductName { get; set; }
+        public int Stock { get; set; }
+    }
+}

--- a/StockApp.Domain.Test/DashboardControllerTests.cs
+++ b/StockApp.Domain.Test/DashboardControllerTests.cs
@@ -1,0 +1,112 @@
+﻿using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using StockApp.API.Controllers;
+using StockApp.Infra.Data.Context;
+using StockApp.Domain.Entities;
+using StockApp.Application.DTOs;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+namespace StockApp.Domain.Test
+{
+    public class DashboardControllerTests
+    {
+        [Fact]
+        public async Task GetDashboardstockData_ReturnsCorrectData_WhenNoLowStockProducts()
+        {
+            using (var context = new ApplicationDbContext(
+                new DbContextOptionsBuilder<ApplicationDbContext>()
+                    .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                    .Options))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                var products = new List<Product>
+                {
+                    new Product(1, "Produto A", "Descrição A", 100.00m, 15, "imageA.jpg"),
+                    new Product(2, "Produto B", "Descrição B", 50.00m, 20, "imageB.jpg"),
+                    new Product(3, "Produto C", "Descrição C", 200.00m, 12, "imageC.jpg")
+                };
+
+                context.Products.AddRange(products);
+                await context.SaveChangesAsync();
+
+                var controller = new DashboardController(context);
+                var result = await controller.GetDashboardstockData();
+
+                var okResult = Assert.IsType<OkObjectResult>(result);
+                var dashboardData = Assert.IsType<DashboardstockDTO>(okResult.Value);
+
+                Assert.Equal(3, dashboardData.TotalProducts);
+                Assert.Equal(15 * 100.00m + 20 * 50.00m + 12 * 200.00m, dashboardData.TotalStockValue);
+                Assert.Empty(dashboardData.LowStockProducts);
+            }
+        }
+
+        [Fact]
+        public async Task GetDashboardstockData_ReturnsCorrectData_WithLowStockProducts()
+        {
+            using (var context = new ApplicationDbContext(
+                new DbContextOptionsBuilder<ApplicationDbContext>()
+                    .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                    .Options))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                var products = new List<Product>
+                {
+                    new Product(1, "Produto X", "Descrição X", 100.00m, 5, "imageX.jpg"),
+                    new Product(2, "Produto Y", "Descrição Y", 50.00m, 20, "imageY.jpg"),
+                    new Product(3, "Produto Z", "Descrição Z", 200.00m, 8, "imageZ.jpg")
+                };
+
+                context.Products.AddRange(products);
+                await context.SaveChangesAsync();
+
+                var controller = new DashboardController(context);
+                var result = await controller.GetDashboardstockData();
+
+                var okResult = Assert.IsType<OkObjectResult>(result);
+                var dashboardData = Assert.IsType<DashboardstockDTO>(okResult.Value);
+
+                Assert.Equal(3, dashboardData.TotalProducts);
+                Assert.Equal(5 * 100.00m + 20 * 50.00m + 8 * 200.00m, dashboardData.TotalStockValue);
+                Assert.Equal(2, dashboardData.LowStockProducts.Count);
+
+                var lowStockProduct1 = Assert.Single(dashboardData.LowStockProducts, p => p.ProductName == "Produto X");
+                Assert.Equal(5, lowStockProduct1.Stock);
+
+                var lowStockProduct2 = Assert.Single(dashboardData.LowStockProducts, p => p.ProductName == "Produto Z");
+                Assert.Equal(8, lowStockProduct2.Stock);
+            }
+        }
+
+        [Fact]
+        public async Task GetDashboardstockData_ReturnsEmptyData_WhenNoProducts()
+        {
+            using (var context = new ApplicationDbContext(
+                new DbContextOptionsBuilder<ApplicationDbContext>()
+                    .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                    .Options))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                var controller = new DashboardController(context);
+                var result = await controller.GetDashboardstockData();
+
+                var okResult = Assert.IsType<OkObjectResult>(result);
+                var dashboardData = Assert.IsType<DashboardstockDTO>(okResult.Value);
+
+                Assert.Equal(0, dashboardData.TotalProducts);
+                Assert.Equal(0, dashboardData.TotalStockValue);
+                Assert.Empty(dashboardData.LowStockProducts);
+            }
+        }
+    }
+}

--- a/StockApp.Domain.Test/DiscountsControllerTests.cs
+++ b/StockApp.Domain.Test/DiscountsControllerTests.cs
@@ -1,0 +1,69 @@
+﻿using Xunit;
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using StockApp.API.Controllers;
+using StockApp.Application.Interfaces;
+using System.Threading.Tasks;
+
+namespace StockApp.Domain.Test
+{
+    public class DiscountsControllerTests
+    {
+        [Fact]
+        public void ApplyDiscount_ReturnsOkResult_WithCorrectCalculatedPrice()
+        {
+            var mockDiscountService = new Mock<IDiscountService>();
+            decimal initialPrice = 100.0m;
+            decimal discount = 10.0m;
+            decimal expectedFinalPrice = 90.0m;
+
+            mockDiscountService.Setup(s => s.ApplyDiscount(initialPrice, discount))
+                               .Returns(expectedFinalPrice);
+
+            var controller = new DiscountsController(mockDiscountService.Object);
+
+            var result = controller.ApplyDiscount(initialPrice, discount);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(expectedFinalPrice, okResult.Value);
+
+            mockDiscountService.Verify(s => s.ApplyDiscount(initialPrice, discount), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(50.0, 20.0, 40.0)]
+        [InlineData(200.0, 50.0, 100.0)]
+        public void ApplyDiscount_ReturnsOkResult_WithVariousInputs(decimal price, decimal percentage, decimal expected)
+        {
+            var mockDiscountService = new Mock<IDiscountService>();
+            mockDiscountService.Setup(s => s.ApplyDiscount(price, percentage))
+                               .Returns(expected);
+
+            var controller = new DiscountsController(mockDiscountService.Object);
+
+            var result = controller.ApplyDiscount(price, percentage);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(expected, okResult.Value);
+            mockDiscountService.Verify(s => s.ApplyDiscount(price, percentage), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(100.0, -10.0, 110.0)]
+        [InlineData(50.0, 110.0, -5.0)]
+        public void ApplyDiscount_ReturnsOkResult_ForEdgeCasesHandledByService(decimal price, decimal percentage, decimal expected)
+        {
+            var mockDiscountService = new Mock<IDiscountService>();
+            mockDiscountService.Setup(s => s.ApplyDiscount(price, percentage))
+                               .Returns(expected);
+
+            var controller = new DiscountsController(mockDiscountService.Object);
+
+            var result = controller.ApplyDiscount(price, percentage);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(expected, okResult.Value);
+            mockDiscountService.Verify(s => s.ApplyDiscount(price, percentage), Times.Once);
+        }
+    }
+}

--- a/StockApp.Domain.Test/ProductControllerTests.cs
+++ b/StockApp.Domain.Test/ProductControllerTests.cs
@@ -7,6 +7,7 @@ using StockApp.API.Controllers;
 using StockApp.Application.DTOs;
 using StockApp.Application.Interfaces;
 using Xunit;
+using System.Linq; 
 
 namespace StockApp.Domain.Test
 {
@@ -15,7 +16,6 @@ namespace StockApp.Domain.Test
         [Fact]
         public async Task ExportToCsv_ReturnsCsvFile_WithExpectedContent()
         {
-            // Arrange
             var mockService = new Mock<IProductService>();
             var products = new List<ProductDTO>
             {
@@ -27,10 +27,8 @@ namespace StockApp.Domain.Test
 
             var controller = new ProductController(mockService.Object);
 
-            // Act
             var result = await controller.ExportToCsv();
 
-            // Assert
             var fileResult = Assert.IsType<FileContentResult>(result);
             Assert.Equal("text/csv", fileResult.ContentType);
 
@@ -38,7 +36,97 @@ namespace StockApp.Domain.Test
             Assert.Contains("Id,Name,Description,Price,Stock", content);
             Assert.Contains("1,\"Produto A\",\"Descrição A\",10.0,5", content);
             Assert.Contains("2,\"Produto B\",\"Descrição B\",20.0,10", content);
+        }
 
+        [Fact]
+        public async Task CompareProducts_ReturnsOk_WithProducts()
+        {
+            var mockProductService = new Mock<IProductService>();
+            var productIds = new List<int> { 1, 2 };
+            var productsDto = new List<ProductDTO>
+            {
+                new ProductDTO { Id = 1, Name = "Product A", Price = 10.0m, Stock = 100 },
+                new ProductDTO { Id = 2, Name = "Product B", Price = 20.0m, Stock = 50 }
+            };
+
+            mockProductService.Setup(s => s.GetProductsByIdsAsync(productIds))
+                              .ReturnsAsync(productsDto);
+
+            var controller = new ProductController(mockProductService.Object);
+
+            var result = await controller.CompareProducts(productIds);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var returnedProducts = Assert.IsAssignableFrom<IEnumerable<ProductDTO>>(okResult.Value);
+
+            Assert.Equal(2, returnedProducts.Count());
+            Assert.Contains(returnedProducts, p => p.Id == 1);
+            Assert.Contains(returnedProducts, p => p.Id == 2);
+            mockProductService.Verify(s => s.GetProductsByIdsAsync(productIds), Times.Once);
+        }
+
+        [Fact]
+        public async Task CompareProducts_ReturnsBadRequest_WhenProductIdsAreNull()
+        {
+            var mockProductService = new Mock<IProductService>();
+            var controller = new ProductController(mockProductService.Object);
+            List<int> productIds = null;
+
+            var result = await controller.CompareProducts(productIds);
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+            Assert.Equal("A lista de IDs de produtos não pode estar vazia.", badRequestResult.Value);
+            mockProductService.Verify(s => s.GetProductsByIdsAsync(It.IsAny<List<int>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CompareProducts_ReturnsBadRequest_WhenProductIdsAreEmpty()
+        {
+            var mockProductService = new Mock<IProductService>();
+            var controller = new ProductController(mockProductService.Object);
+            var productIds = new List<int>();
+
+            var result = await controller.CompareProducts(productIds);
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+            Assert.Equal("A lista de IDs de produtos não pode estar vazia.", badRequestResult.Value);
+            mockProductService.Verify(s => s.GetProductsByIdsAsync(It.IsAny<List<int>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CompareProducts_ReturnsNotFound_WhenNoProductsFoundByService()
+        {
+            var mockProductService = new Mock<IProductService>();
+            var productIds = new List<int> { 99, 100 };
+
+            mockProductService.Setup(s => s.GetProductsByIdsAsync(productIds))
+                              .ReturnsAsync(Enumerable.Empty<ProductDTO>());
+
+            var controller = new ProductController(mockProductService.Object);
+
+            var result = await controller.CompareProducts(productIds);
+
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+            Assert.Equal("Nenhum produto encontrado para os IDs fornecidos.", notFoundResult.Value);
+            mockProductService.Verify(s => s.GetProductsByIdsAsync(productIds), Times.Once);
+        }
+
+        [Fact]
+        public async Task CompareProducts_ReturnsNotFound_WhenServiceReturnsNull()
+        {
+            var mockProductService = new Mock<IProductService>();
+            var productIds = new List<int> { 99, 100 };
+
+            mockProductService.Setup(s => s.GetProductsByIdsAsync(productIds))
+                              .ReturnsAsync((IEnumerable<ProductDTO>)null);
+
+            var controller = new ProductController(mockProductService.Object);
+
+            var result = await controller.CompareProducts(productIds);
+
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+            Assert.Equal("Nenhum produto encontrado para os IDs fornecidos.", notFoundResult.Value);
+            mockProductService.Verify(s => s.GetProductsByIdsAsync(productIds), Times.Once);
         }
     }
 }

--- a/StockApp.Domain.Test/Services/DiscountServiceTests.cs
+++ b/StockApp.Domain.Test/Services/DiscountServiceTests.cs
@@ -1,0 +1,43 @@
+﻿using Xunit;
+using StockApp.Application.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StockApp.Domain.Test
+{
+    public class DiscountServiceTests
+    {
+        [Theory]
+        [InlineData(100.0, 10.0, 90.0)]
+        [InlineData(50.0, 20.0, 40.0)]
+        [InlineData(75.50, 5.0, 71.725)]
+        [InlineData(100.0, 0.0, 100.0)]
+        [InlineData(200.0, 100.0, 0.0)]
+        [InlineData(0.0, 10.0, 0.0)]
+        public void ApplyDiscount_ShouldCalculateCorrectly(decimal price, decimal discountPercentage, decimal expectedResult)
+        {
+            var service = new DiscountService();
+            var result = service.ApplyDiscount(price, discountPercentage);
+            Assert.Equal(expectedResult, result, 3);
+        }
+
+        [Theory]
+        [InlineData(100.0, -10.0)]
+        [InlineData(50.0, 110.0)]
+        public void ApplyDiscount_ShouldHandleEdgeCases(decimal price, decimal discountPercentage)
+        {
+            var service = new DiscountService();
+            var result = service.ApplyDiscount(price, discountPercentage);
+
+            if (discountPercentage < 0)
+            {
+                Assert.True(result > price);
+            }
+            else if (discountPercentage > 100)
+            {
+                Assert.True(result < 0);
+            }
+        }
+    }
+}

--- a/StockApp.Domain.Test/Services/JustInTimeInventoryServiceTests.cs
+++ b/StockApp.Domain.Test/Services/JustInTimeInventoryServiceTests.cs
@@ -1,0 +1,104 @@
+﻿using Xunit;
+using Moq;
+using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using StockApp.Application.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StockApp.Domain.Test
+{
+    public class JustInTimeInventoryServiceTests
+    {
+        [Fact]
+        public async Task OptimizeInventoryAsync_ShouldReduceStock_WhenStockIsAboveTarget()
+        {
+            var mockProductRepository = new Mock<IProductRepository>();
+            var products = new List<Product>
+            {
+                new Product(1, "ProductA", "DescA", 10.0m, 15, "imageA.png"),
+                new Product(2, "ProductB", "DescB", 20.0m, 8, "imageB.png")
+            };
+
+            mockProductRepository.Setup(repo => repo.GetProducts())
+                                 .ReturnsAsync(products);
+
+            mockProductRepository.Setup(repo => repo.Update(It.IsAny<Product>()))
+                                 .Returns(Task.CompletedTask);
+
+            var service = new JustInTimeInventoryService(mockProductRepository.Object);
+
+            await service.OptimizeInventoryAsync();
+
+            mockProductRepository.Verify(repo => repo.GetProducts(), Times.Once);
+
+            mockProductRepository.Verify(repo => repo.Update(It.Is<Product>(p => p.Id == 1 && p.Stock == 10)), Times.Once);
+
+            mockProductRepository.Verify(repo => repo.Update(It.Is<Product>(p => p.Id == 2)), Times.Never);
+        }
+
+        [Fact]
+        public async Task OptimizeInventoryAsync_ShouldIncreaseStock_WhenStockIsBelowHalfTarget()
+        {
+            var mockProductRepository = new Mock<IProductRepository>();
+            var products = new List<Product>
+            {
+                new Product(1, "ProductA", "DescA", 10.0m, 3, "imageA.png"),
+                new Product(2, "ProductB", "DescB", 20.0m, 7, "imageB.png")
+            };
+
+            mockProductRepository.Setup(repo => repo.GetProducts())
+                                 .ReturnsAsync(products);
+
+            mockProductRepository.Setup(repo => repo.Update(It.IsAny<Product>()))
+                                 .Returns(Task.CompletedTask);
+
+            var service = new JustInTimeInventoryService(mockProductRepository.Object);
+
+            await service.OptimizeInventoryAsync();
+
+            mockProductRepository.Verify(repo => repo.GetProducts(), Times.Once);
+
+            mockProductRepository.Verify(repo => repo.Update(It.Is<Product>(p => p.Id == 1 && p.Stock == 10)), Times.Once);
+
+            mockProductRepository.Verify(repo => repo.Update(It.Is<Product>(p => p.Id == 2)), Times.Never);
+        }
+
+        [Fact]
+        public async Task OptimizeInventoryAsync_ShouldNotModifyStock_WhenStockIsWithinTargetRange()
+        {
+            var mockProductRepository = new Mock<IProductRepository>();
+            var products = new List<Product>
+            {
+                new Product(1, "ProductA", "DescA", 10.0m, 7, "imageA.png"),
+                new Product(2, "ProductB", "DescB", 20.0m, 10, "imageB.png")
+            };
+
+            mockProductRepository.Setup(repo => repo.GetProducts())
+                                 .ReturnsAsync(products);
+
+            var service = new JustInTimeInventoryService(mockProductRepository.Object);
+
+            await service.OptimizeInventoryAsync();
+            mockProductRepository.Verify(repo => repo.GetProducts(), Times.Once);
+            mockProductRepository.Verify(repo => repo.Update(It.IsAny<Product>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task OptimizeInventoryAsync_HandlesNoProductsGracefully()
+        {
+            var mockProductRepository = new Mock<IProductRepository>();
+
+            mockProductRepository.Setup(repo => repo.GetProducts())
+                                 .ReturnsAsync(new List<Product>());
+
+            var service = new JustInTimeInventoryService(mockProductRepository.Object);
+
+            await service.OptimizeInventoryAsync();
+
+            mockProductRepository.Verify(repo => repo.GetProducts(), Times.Once);
+            mockProductRepository.Verify(repo => repo.Update(It.IsAny<Product>()), Times.Never);
+        }
+    }
+}

--- a/StockApp.Domain.Test/Services/ProductServiceTests.cs
+++ b/StockApp.Domain.Test/Services/ProductServiceTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using StockApp.Infra.Data.Context;
 using Microsoft.EntityFrameworkCore;
-using Moq.EntityFrameworkCore;
+
 
 namespace StockApp.Domain.Test
 {

--- a/StockApp.Domain.Test/StockApp.Domain.Test.csproj
+++ b/StockApp.Domain.Test/StockApp.Domain.Test.csproj
@@ -8,12 +8,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.28" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Moq.EntityFrameworkCore" Version="7.0.0.2" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-		<PackageReference Include="coverlet.collector" Version="3.1.2" />
+		<PackageReference Include="xunit" Version="2.6.6" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/StockApp.Domain/Interfaces/IProductRepository.cs
+++ b/StockApp.Domain/Interfaces/IProductRepository.cs
@@ -9,7 +9,7 @@ namespace StockApp.Domain.Interfaces
         Task<IEnumerable<Product>> GetProducts();
         Task<Product> GetById(int? id);
         Task<Product> Create(Product product);
-        Task<Product> Update(Product product);
+        Task Update(Product product);
         Task<Product> Remove(Product product);
         Task<IEnumerable<Product>> GetAllAsync(int pageNumber, int pageSize);
         Task<IEnumerable<Product>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice);

--- a/StockApp.Infra.Data/Context/ApplicationDbContext.cs
+++ b/StockApp.Infra.Data/Context/ApplicationDbContext.cs
@@ -1,28 +1,27 @@
-﻿using Microsoft.EntityFrameworkCore;
-using StockApp.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿    using Microsoft.EntityFrameworkCore;
+    using StockApp.Domain.Entities;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
 
-namespace StockApp.Infra.Data.Context
-{
-    public class ApplicationDbContext : DbContext
+    namespace StockApp.Infra.Data.Context
     {
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) 
-            : base(options)
-        { }
-        //sqlservericoma.database.windows.net
-        public DbSet<Category> Categories { get; set; }
-        public DbSet<Product> Products { get; set; }
-        public DbSet<Feedback> Feedbacks { get; set; }
-        public DbSet<Review> Reviews { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder builder)
+        public class ApplicationDbContext : DbContext
         {
-            base.OnModelCreating(builder);
-            builder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
+            public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) 
+                : base(options)
+            { }
+            public DbSet<Category> Categories { get; set; }
+            public virtual DbSet<Product> Products { get; set; }
+            public DbSet<Feedback> Feedbacks { get; set; }
+            public DbSet<Review> Reviews { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder builder)
+            {
+                base.OnModelCreating(builder);
+                builder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
+            }
         }
     }
-}

--- a/StockApp.Infra.Data/Repositories/ProductRepository.cs
+++ b/StockApp.Infra.Data/Repositories/ProductRepository.cs
@@ -42,7 +42,7 @@ namespace StockApp.Infra.Data.Repositories
             return product;
         }
 
-        public async Task<Product> Update(Product product)
+        public async Task Update(Product product)
         {
             var existingEntity = _productContext.Products.Local.FirstOrDefault(p => p.Id == product.Id);
 
@@ -56,10 +56,11 @@ namespace StockApp.Infra.Data.Repositories
                 _productContext.Entry(product).State = EntityState.Modified;
             }
 
+           
             _productContext.Entry(product.Category).State = EntityState.Unchanged;
 
             await _productContext.SaveChangesAsync();
-            return product;
+            
         }
 
         public async Task<IEnumerable<Product>> SearchAsync(string name, decimal? minPrice, decimal? maxPrice)


### PR DESCRIPTION
Foi criado um novo endpoint GET /api/dashboard/dashboard-stock que retorna dados agregados relevantes para a visualização do estoque. Este endpoint fornece as seguintes métricas:

Total de Produtos: Contagem total de todos os produtos no sistema.

Valor Total do Estoque: Soma do valor de todos os produtos em estoque (quantidade * preço).

Produtos com Baixo Estoque: Uma lista dos produtos cujo estoque está abaixo de um limite pré-definido (atualmente 10 unidades), incluindo o nome do produto e a quantidade em estoque.

Esta implementação visa fornecer uma visão rápida e consolidada do estado do inventário, auxiliando na gestão e tomada de decisões.

Observações (para você, não inclua na PR):

Se houver um DTO específico que você criou para o retorno (ex: DashboardStockDto), você pode mencionar brevemente: "As informações são retornadas através do DashboardStockDto."

Closes #92