### PR TITLE
fix: corrigir inclusão e configuração do arquivo .env

### DIFF
--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -18,6 +18,8 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
+Env.Load();
+
 // Configuração do Serilog
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -29,7 +31,7 @@ builder.Host.UseSerilog();
 // Variáveis de ambiente
 builder.Configuration.AddEnvironmentVariables();
 
-string connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
 
 // Para ambiente de teste, usar uma connection string padrão se não estiver configurada
 if (string.IsNullOrEmpty(connectionString))

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="3.0.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.27" />
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />

--- a/StockApp.API/appsettings.json
+++ b/StockApp.API/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=DESKTOP-OPQGCVT\\RAMON;Database=StockAppLocalDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": ""
   },
   "AllowedHosts": "*",
   "Jwt": {

--- a/StockApp.Domain/StockApp.Domain.csproj
+++ b/StockApp.Domain/StockApp.Domain.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/StockApp.Infra.Data/Context/ApplicationDbContextFactory.cs
+++ b/StockApp.Infra.Data/Context/ApplicationDbContextFactory.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
 using System.IO;
+using DotNetEnv;
 
 
 namespace StockApp.Infra.Data.Context
@@ -10,7 +11,7 @@ namespace StockApp.Infra.Data.Context
     {
         public ApplicationDbContext CreateDbContext(string[] args)
         {
-
+            Env.Load();
             var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
             var basePath = Directory.GetCurrentDirectory();
 
@@ -19,7 +20,7 @@ namespace StockApp.Infra.Data.Context
                 .AddJsonFile("appsettings.json")
                 .Build();
 
-            var connectionString = configuration.GetConnectionString("DefaultConnection");
+            var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
 
             optionsBuilder.UseSqlServer(connectionString);
 

--- a/StockApp.Infra.Data/StockApp.Infra.Data.csproj
+++ b/StockApp.Infra.Data/StockApp.Infra.Data.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.28">


### PR DESCRIPTION
O que foi feito:

Readição do arquivo .env que havia sido removido ou perdido no merge anterior.

Correção na configuração para garantir que as variáveis de ambiente sejam corretamente carregadas no projeto.

Atualização do .gitignore para evitar que o arquivo .env seja enviado ao repositório, garantindo segurança das informações sensíveis.

Por que foi feito:
Para assegurar que as configurações sensíveis e variáveis de ambiente estejam protegidas e funcionando corretamente, evitando exposição de dados e erros na conexão com banco de dados ou outras integrações.

Como testar:

Verificar que o .env está presente localmente e não está no repositório remoto.

Testar a aplicação para garantir que as variáveis do .env estão sendo usadas corretamente (ex: conexão com banco, API keys, etc).

Confirmar que o .gitignore impede o commit do .env.